### PR TITLE
the leading number in var name

### DIFF
--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -297,7 +297,7 @@ class Compiler {
 
             $name = $get_middle_string($sep, $get_next(key($separators)));
 
-            $v = "\${$ns}__";
+            $v = "\$__{$ns}";
             switch ($sep[0]) {
                 // translate the javascript's obj.attr into php's obj->attr or obj['attr']
                 case '.':


### PR DESCRIPTION
```
!{base64_encode(json_encode('aaaaaa'))}
```

get

``` php
$0__=json_encode($params);
$__=base64_encode($0__);
echo $__
```

which cause a complie error
