### PR TITLE
Added boolean handling for the checked attribute

### DIFF
--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -876,7 +876,13 @@ class Compiler {
 
                 if ($json !== null && is_array($json) && $key == 'class') {
                     $value = implode(' ', $json);
-                }else{
+                }
+                elseif ($key == "checked") {
+                    // boolean checked handling
+                    $items[] = $this->createCode(' if (%1$s) { echo "checked=\'checked\'"; }', $value);
+                    continue;
+                }
+                else{
                     // inline this in the tag
                     $pp = $this->prettyprint;
                     $this->prettyprint = false;


### PR DESCRIPTION
this allows to conditionally generate the checked attribute on radio buttons or checkboxes.

example:

``` jade
input(type="radio", name="test", value="1", checked=checkedOne)
input(type="radio", name="test", value="2", checked=checkedTwo)
```

if $checkedOne is set to a truthy value, the checked attribute will be added to the generated php otherwise it is omitted completely.
