### PR TITLE
fix treating object as array - additional check added

### DIFF
--- a/src/Jade/Compiler.php
+++ b/src/Jade/Compiler.php
@@ -296,7 +296,7 @@ class Compiler {
                 // translate the javascript's obj.attr into php's obj->attr or obj['attr']
                 case '.':
                     // TODO: Move isset(->)?->:[]; to a function
-                    $accessor= "{$v}=isset({$varname}->{$name}) ? {$varname}->{$name} : {$varname}['{$name}']";
+                    $accessor= "{$v}=isset({$varname}->{$name}) ? {$varname}->{$name} : ((!is_object({$varname}))?({$varname}['{$name}']):'')";
                     array_push($result, $accessor);
                     $varname = $v;
 


### PR DESCRIPTION
Having an object $user and it's property $user->page not set but is requested from jade template leads to a situation when a compiled template tries to output $user['page'] and PHP exits with an error.

Needs some tests added. Haven't tested it with unit tests.
